### PR TITLE
Add cmd-clojure and cmd-clj shims

### DIFF
--- a/clojure.json
+++ b/clojure.json
@@ -9,6 +9,18 @@
     "psmodule": {
         "name": "ClojureTools"
     },
+    "bin": [
+        [
+            "powershell.exe",
+            "cmd-clojure",
+            "-NoProfile -ExecutionPolicy Bypass -Command Invoke-Clojure"
+        ],
+        [
+            "powershell.exe",
+            "cmd-clj",
+            "-NoProfile -ExecutionPolicy Bypass -Command Invoke-Clojure"
+        ]
+    ],
     "suggest": {
         "JDK": [
             "java/adopt8-hotspot",
@@ -25,3 +37,4 @@
         "url": "https://download.clojure.org/install/clojure-tools-$version.zip"
     }
 }
+

--- a/scripts/clojure.sh
+++ b/scripts/clojure.sh
@@ -34,6 +34,18 @@ cat <<MANIFEST
     "psmodule": {
         "name": "ClojureTools"
     },
+    "bin": [
+        [
+            "powershell.exe",
+            "cmd-clojure",
+            "-NoProfile -ExecutionPolicy Bypass -Command Invoke-Clojure"
+        ],
+        [
+            "powershell.exe",
+            "cmd-clj",
+            "-NoProfile -ExecutionPolicy Bypass -Command Invoke-Clojure"
+        ]
+    ],
     "suggest": {
         "JDK": [
             "java/adopt8-hotspot",


### PR DESCRIPTION
- clj and clojure are Powershell aliases and as such cannot be used directly from cmd.exe
- this experiments adds cmd-clj and cmd-clojure shims allow to run tooling from cmd.exe
- powershell is still required to be installed on the box