### PR TITLE
Update bootleg, v0.1.8

### DIFF
--- a/bootleg.json
+++ b/bootleg.json
@@ -2,11 +2,11 @@
     "description": "Simple template processing command line tool to help build static websites",
     "homepage": "https://github.com/retrogradeorbit/bootleg",
     "license": "EPL-2.0",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/retrogradeorbit/bootleg/releases/download/v0.1.7/bootleg-0.1.7-windows-amd64.zip",
-            "hash": "340c1ef0ec759658cf8ffce6528c43ccce3af17804c1955aadc82834604f024c"
+            "url": "https://github.com/retrogradeorbit/bootleg/releases/download/v0.1.8/bootleg-0.1.8-windows-amd64.zip",
+            "hash": "363ab9266117882c331ababc5674b50c77b5df4899785dd1aa2cdc874891bc10"
         }
     },
     "suggest": {


### PR DESCRIPTION
From the release notes:
- add babashka pod support
- YAML upgrade to SnakeYAML 2.0
- Fix Build failed when trying build with graalvm-ce-java11-19.3.0
- Fix the ns/require code from spire in bootleg?
- Fix Running from file in same directory requires leading ./
- Fix Generating XML preserving the tag name case
- Fix reflection error preventing XML roundtrip