### PR TITLE
clojure: Update to version 1.10.1.739

### DIFF
--- a/clojure.json
+++ b/clojure.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://clojure.org",
     "description": "Clojure is a modern, dynamic, and functional dialect of the Lisp programming language on the Java platform",
-    "version": "1.10.1.727",
+    "version": "1.10.1.739",
     "license": "EPL-1.0",
-    "url": "https://download.clojure.org/install/clojure-tools-1.10.1.727.zip",
-    "hash": "ab8d2aff4e35995bf18edbc9dc2bc1738cd9fbee2cc6713673d0c2e6a16fd8c0",
+    "url": "https://download.clojure.org/install/clojure-tools-1.10.1.739.zip",
+    "hash": "a03bfd88de7670db8d6d9275ac0b78da95ad82fc78f10dc0c98cfbcc3d0234eb",
     "extract_dir": "ClojureTools",
     "psmodule": {
         "name": "ClojureTools"


### PR DESCRIPTION
- Fix use of jdk profile activation in local deps with pom files
- Fix error handling for -X to avoid double throw
- Add error handling for -A used without an alias
- Use tools.deps.alpha 0.9.840