### PR TITLE
clojure-lsp: Add depends on extras/vcredist2015

### DIFF
--- a/bucket/clojure-lsp.json
+++ b/bucket/clojure-lsp.json
@@ -3,6 +3,7 @@
     "description": "Language Server for Clojure",
     "homepage": "https://clojure-lsp.github.io/clojure-lsp",
     "license": "MIT",
+    "depends": "extras/vcredist2015",
     "architecture": {
         "64bit": {
             "url": "https://github.com/clojure-lsp/clojure-lsp/releases/download/2021.02.07-03.04.31/clojure-lsp-native-windows-amd64.zip",


### PR DESCRIPTION
Fix eventual missing dependency on vcredist2015 dynamic library