### PR TITLE
datalevin: Add version 0.4.25

### DIFF
--- a/bucket/datalevin.json
+++ b/bucket/datalevin.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.4.25",
+    "description": "A simple, fast and durable Datalog database",
+    "homepage": "https://github.com/juji-io/datalevin",
+    "license": "EPL-1.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/juji-io/datalevin/releases/download/0.4.25/dtlv-0.4.25-windows-amd64.zip",
+            "hash": "e2b3cd8792cfc42f4a1fa08c590cc60dfe9c9b309e34fb7bab1397a232de76d9"
+        }
+    },
+    "bin": "dtlv.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/juji-io/datalevin/releases/download/$version/dtlv-$version-windows-amd64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Datalevin is a simple durable Datalog database.

The rationale is to have a simple, fast and free Datalog query engine running on durable storage. It is our observation that many developers prefer the flavor of Datalog popularized by Datomic® over any flavor of SQL, once they get to use it. Perhaps it is because Datalog is more declarative and composable than SQL, e.g. the automatic implicit joins seem to be its killer feature.