### PR TITLE
pathom-viz: Add version 2021.4.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ cmd-clojure
 - [grasp](https://github.com/borkdude/grasp): (development preview) Grep Clojure code using clojure.spec regexes
 - [jet](https://github.com/borkdude/jet): CLI to transform between JSON, EDN and Transit, powered with a minimal query language
 - [joker](https://joker-lang.org): A small interpreted dialect of Clojure written in Go. It is also a Clojure(Script) linter
+- [pathom-viz](https://github.com/wilkerlucio/pathom-viz): Visualization tools for Pathom
 - [pgmig](https://github.com/leafclick/pgmig): Standalone PostgreSQL migration runner
 - [puget](https://github.com/borkdude/puget-cli): A CLI version of puget
 
@@ -101,6 +102,7 @@ scoop install deps.clj
 scoop install grasp        # development preview
 scoop install jet
 scoop install joker
+scoop install pathom-viz
 scoop install pgmig
 scoop install puget
 ```

--- a/bucket/pathom-viz.json
+++ b/bucket/pathom-viz.json
@@ -1,0 +1,27 @@
+{
+    "version": "2021.4.22",
+    "description": "Visualization tools for Pathom",
+    "homepage": "https://github.com/wilkerlucio/pathom-viz",
+    "license": "Freeware",
+    "url": "https://github.com/wilkerlucio/pathom-viz/releases/download/v2021.4.22/Pathom-Viz-Setup-2021.4.22.exe#/dl.7z",
+    "hash": "10de09336dcca741d09e58a88a0beef238f64a4b3da9376ad256e9748d5e537b",
+    "architecture": {
+        "64bit": {
+            "installer": {
+                "script": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+            }
+        }
+    },
+    "bin": "Pathom Viz.exe",
+    "shortcuts": [
+        [
+            "Pathom Viz.exe",
+            "Pathom Viz"
+        ]
+    ],
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/wilkerlucio/pathom-viz/releases/download/v$version/Pathom-Viz-Setup-$version.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
Pathom viz is a set of visualization tools to support the development and inspection of Graph API’s built with the Pathom library