### PR TITLE
babashka: Add curl to suggest section

### DIFF
--- a/bucket/babashka.json
+++ b/bucket/babashka.json
@@ -4,6 +4,9 @@
     "homepage": "https://github.com/borkdude/babashka",
     "license": "EPL-1.0",
     "depends": "extras/vcredist2015",
+    "suggest": {
+        "curl": "curl"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/borkdude/babashka/releases/download/v0.4.1/babashka-0.4.1-windows-amd64.zip",


### PR DESCRIPTION
Current version of Windows is bundled with the older version of `curl` tool which causes trouble on some occasions.
See https://github.com/babashka/babashka.curl/issues/36

As a result I added curl to suggest section of the manifest, so user have a change to grab the newer  version out of scoop main bucket.

Setting up PATH properly to take precedence over bundled curl may be still required though.