### PR TITLE
neil: Generate shim from manifest

### DIFF
--- a/bucket/neil.json
+++ b/bucket/neil.json
@@ -11,6 +11,7 @@
             "extract_dir": "neil-0.0.17"
         }
     },
+    "pre_install": "Set-Content \"$dir\\neil.bat\" \"@bb.exe \"\"%~dp0neil\"\" %*\"",
     "bin": "neil.bat",
     "checkver": {
         "url": "https://api.github.com/repos/babashka/neil/tags",


### PR DESCRIPTION
Previously this depends on neil.bat from neil repository. But this is how shim can be generated form the manifest.