### PR TITLE
clojure: Change jdk suggestion

### DIFF
--- a/bucket/clojure.json
+++ b/bucket/clojure.json
@@ -5,10 +5,9 @@
     "license": "EPL-1.0",
     "suggest": {
         "JDK": [
-            "java/adopt8-hotspot",
-            "java/adoptopenjdk-lts-hotspot",
-            "java/oraclejdk",
-            "java/openjdk"
+            "java/openjdk",
+            "java/temurin-jdk",
+            "java/oraclejdk"
         ]
     },
     "url": "https://download.clojure.org/install/clojure-tools-1.10.3.1087.zip",


### PR DESCRIPTION
- Remove suggestion adopopenjdk, use temurin instead.
- Remove suggestion of jdk version 8.