### PR TITLE
trenchman: Add version 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ cmd-clojure
 - [pgmig](https://github.com/leafclick/pgmig): Standalone PostgreSQL migration runner
 - [puget](https://github.com/borkdude/puget-cli): A CLI version of puget
 - [shh](https://github.com/askonomm/shh): A CLI password manager designed for efficiency
+- [trenchman](https://github.com/athos/trenchman): A standalone nREPL/prepl client written in Go and heavily inspired by [Grenchman](https://github.com/technomancy/grenchman)
 
 ## Babashka based utilities
 
@@ -119,6 +120,7 @@ scoop install pathom-viz
 scoop install pgmig
 scoop install puget
 scoop install shh
+scoop install trenchman
 ```
 
 or babashka based utilities:

--- a/bucket/trenchman.json
+++ b/bucket/trenchman.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.4.0",
+    "description": "A standalone nREPL/prepl client written in Go and heavily inspired by Grenchman",
+    "homepage": "https://github.com/athos/trenchman",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/athos/trenchman/releases/download/v0.4.0/trenchman_0.4.0_windows_amd64.zip",
+            "hash": "8b457e9be5f4cb64820cabad60e6763d5102aea365f4359a07cf7f20360446cb"
+        }
+    },
+    "bin": "trench.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/athos/trenchman/releases/download/v$version/trenchman_$version_windows_amd64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Trenchman is a standalone nREPL/prepl client, which means that it can be used as an ordinary REPL without having to make it cooperate with an editor or any other development tool. Unlike ordinary Clojure REPLs, it starts up instantly as it just connects to a running nREPL/prepl server, eliminating the overhead of launching a JVM process and bootstrapping Clojure for every startup.

Features
- Fast startup
- Written in Go and runs on various platforms
- Support for nREPL and prepl
- Works as a language-agnostic nREPL client