### PR TITLE
fix(bbin): Fix wrong path to project and artifact

### DIFF
--- a/bucket/bbin.json
+++ b/bucket/bbin.json
@@ -6,8 +6,8 @@
     "depends": "scoop-clojure/babashka",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/babashka/neil/archive/refs/tags/v0.0.11.zip",
-            "hash": "200b0c931609407a8876bade9472f92816b5e7c0775dc5bb2dc6ae98b74247e7",
+            "url": "https://github.com/babashka/bbin/archive/refs/tags/v0.0.11.zip",
+            "hash": "e4047b113bb28ba2a4953ae6b76fa0d6569ee191cedf8005c46201d0a9007ea8",
             "extract_dir": "bbin-0.0.11"
         }
     },
@@ -29,7 +29,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/babashka/neil/archive/refs/tags/v$version.zip",
+                "url": "https://github.com/babashka/bbin/archive/refs/tags/v$version.zip",
                 "extract_dir": "bbin-$version"
             }
         }


### PR DESCRIPTION
For some unknown reason, automation have rewritten path to a project from bbin to neil. Don't know what caused this.