### PR TITLE
clj-msi: Add version 1.11.1.1182

### DIFF
--- a/bucket/clj-msi.json
+++ b/bucket/clj-msi.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.11.1.1182",
+    "description": "Clojure installation from a MSI package",
+    "homepage": "https://clojure.org",
+    "license": "EPL-1.0",
+    "notes": [
+        "Please fully exit and restart any active terminal sessions."
+    ],
+    "suggest": {
+        "JDK": [
+            "java/openjdk",
+            "java/temurin-jdk",
+            "java/oraclejdk"
+        ]
+    },
+    "url": "https://github.com/casselc/clj-msi/releases/download/1.11.1.1182/clojure-1.11.1.1182.msi",
+    "hash": "76f5da5bb1c6b16b54a1ce26d85f5ca40cfccb33cacc52515aa63bc53f13cfcc",
+    "env_set": {
+        "DEPS_CLJ_TOOLS_DIR": "$dir"
+    },
+    "bin": [
+        "clj.exe",
+        "clojure.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/casselc/clj-msi"
+    },
+    "autoupdate": {
+        "url": "https://github.com/casselc/clj-msi/releases/download/$version/clojure-$version.msi"
+    }
+}

--- a/bucket/clj-msi.json
+++ b/bucket/clj-msi.json
@@ -23,7 +23,8 @@
         "clojure.exe"
     ],
     "checkver": {
-        "github": "https://github.com/casselc/clj-msi"
+        "url": "https://api.github.com/repos/casselc/clj-msi/tags",
+        "regex": "\"v([\\d.]+)\""
     },
     "autoupdate": {
         "url": "https://github.com/casselc/clj-msi/releases/download/$version/clojure-$version.msi"


### PR DESCRIPTION
Installs Clojure using unofficial MSI installer in the making by @casselc
I did a quick round of testing and it works great as a source for a Clojure installation.

Few notes:
- This works in a way all the installations usint Scoop installer + MSI works, it uncompress the cabinet and setup all necessary stuff so it fits into Scoop structures and sets environment variables etc. 
- It relies on the fact that internal structure of the MSI package wont change drastically once established
- It's based on Pre-release, so don't depend on it too much yet. But we are getting there!
- I won't list this on the README as an installation option yet until it's out of pre-release