### PR TITLE
clj-msi: Update to version 1.11.1.1189 with manifest fixes

### DIFF
--- a/bucket/clj-msi.json
+++ b/bucket/clj-msi.json
@@ -13,8 +13,8 @@
             "java/oraclejdk"
         ]
     },
-    "url": "https://github.com/casselc/clj-msi/releases/download/1.11.1.1182/clojure-1.11.1.1182.msi",
-    "hash": "76f5da5bb1c6b16b54a1ce26d85f5ca40cfccb33cacc52515aa63bc53f13cfcc",
+    "url": "https://github.com/casselc/clj-msi/releases/download/v1.11.1.1189/clojure-1.11.1.1189.msi",
+    "hash": "b7be166440dcc3265d8419bcd4fb3882f7923cc68f3c37cd45c244bfd8347dd8",
     "pre_install": [
         "Move-Item \"$dir\\PFiles\\clojure\\*\" \"$dir\\\"",
         "Remove-Item \"$dir\\PFiles\" -Force -Recurse"
@@ -27,10 +27,9 @@
         "clojure.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/casselc/clj-msi/tags",
-        "regex": "\"v([\\d.]+)\""
+        "github": "https://github.com/casselc/clj-msi"
     },
     "autoupdate": {
-        "url": "https://github.com/casselc/clj-msi/releases/download/$version/clojure-$version.msi"
+        "url": "https://github.com/casselc/clj-msi/releases/download/v$version/clojure-$version.msi"
     }
 }


### PR DESCRIPTION
- artifact location change
- use github defaults for checkver