### PR TITLE
clj-deps: Add version 1.11.1.1200

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Now we are ready to install Java and Clojure by issuing following commands:
 scoop install temurin-lts-jdk
 
 # install official clojure tools
-scoop install clojure
+scoop install clj-deps
 
 # update to the newest version
-scoop update clojure
+scoop update clj-deps
 ```
 
 After successfully running steps above, you should be able to run Clojure with following:
@@ -52,12 +52,7 @@ After successfully running steps above, you should be able to run Clojure with f
 clj
 ```
 
-To launch clojure from `cmd.exe` or tools like Emacs, you can use prepared shims:
-
-```sh
-cmd-clj
-cmd-clojure
-```
+Emacs users should now issue `clj` and `clojure` commands without hassle.
 
 ## Other tools available in this bucket
 
@@ -71,7 +66,6 @@ cmd-clojure
 - [clojure-lsp](https://github.com/clojure-lsp/clojure-lsp): Language server for Clojure
 - [cq](https://github.com/markus-wa/cq): Clojure Command-line Data Processor for JSON, YAML, EDN, XML and more
 - [datalevin](https://github.com/juji-io/datalevin): A simple, fast and durable Datalog database
-- [deps.clj](https://github.com/borkdude/deps.clj): A port of the clojure bash script to Clojure
 - [grasp](https://github.com/borkdude/grasp): Grep Clojure code using clojure.spec regexes
 - [jet](https://github.com/borkdude/jet): CLI to transform between JSON, EDN and Transit, powered with a minimal query language
 - [joker](https://joker-lang.org): A small interpreted dialect of Clojure written in Go. It is also a Clojure(Script) linter
@@ -113,7 +107,6 @@ scoop install clj-kondo
 scoop install clojure-lsp
 scoop install cq
 scoop install datalevin
-scoop install deps.clj
 scoop install grasp
 scoop install jet
 scoop install joker
@@ -146,7 +139,7 @@ scoop update *
 If you had enough of Clojure for some reason. It's easy to uninstall it using scoop:
 
 ```sh
-scoop uninstall clojure
+scoop uninstall clj-deps
 ```
 
 Also applies to every tool above.

--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -1,0 +1,52 @@
+{
+    "version": "1.11.1.1200",
+    "description": "Modern, dynamic a functional dialect of the LISP programming language for JVM",
+    "homepage": "https://clojure.org",
+    "license": "EPL-1.0",
+    "notes": "Please fully exit and restart any active terminal sessions.",
+    "suggest": {
+        "JDK": [
+            "java/openjdk",
+            "java/temurin-jdk",
+            "java/oraclejdk"
+        ]
+    },
+    "depends": "extras/vcredist2015",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://github.com/borkdude/deps.clj/releases/download/v1.11.1.1200/deps.clj-1.11.1.1200-windows-amd64.zip",
+                "https://download.clojure.org/install/clojure-tools-1.11.1.1200.zip"
+            ],
+            "hash": [
+                "c7530eb8533d5f90ff38b3127dfa102289ab8e6e86c4583219dec74d6542ecc5",
+                "6d121c6712d31c2fef2fbf477da22ff5b183a9687c698ffb79d094719d9c391e"
+            ]
+        }
+    },
+    "pre_install": [
+        "Move-Item \"$dir\\ClojureTools\\*\" \"$dir\\\" -Exclude 'ClojureTools.p*'",
+        "Remove-Item \"$dir\\ClojureTools\" -Force -Recurse"
+    ],
+    "env_set": {
+        "DEPS_CLJ_TOOLS_DIR": "$dir"
+    },
+    "bin": [
+        ["deps.exe", "deps"],
+        ["deps.exe", "clojure"],
+        ["deps.exe", "clj"]
+    ],
+    "checkver": {
+        "github": "https://github.com/borkdude/deps.clj"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": [
+                    "https://github.com/borkdude/deps.clj/releases/download/v$version/deps.clj-$version-windows-amd64.zip",
+                    "https://download.clojure.org/install/clojure-tools-$version.zip"
+                ]
+            }
+        }
+    }
+}

--- a/bucket/clojure.json
+++ b/bucket/clojure.json
@@ -3,7 +3,14 @@
     "description": "Clojure is a modern, dynamic, and functional dialect of the Lisp programming language on the Java platform",
     "homepage": "https://clojure.org",
     "license": "EPL-1.0",
-    "notes": "Please fully exit and restart any active terminal sessions.",
+    "notes": [
+        "Please fully exit and restart any active terminal sessions.",
+        "-----------------------------------------------------------",
+        "IMPORTANT NOTICE: This is no longer prefered way to install Clojure on Windows.",
+        "To migrate execute following:",
+        "   scoop uninstall clojure",
+        "   scoop install clj-deps"
+    ],
     "suggest": {
         "JDK": [
             "java/openjdk",


### PR DESCRIPTION
This is a new way to install Clojure on Windows.
- It uses deps.exe from our own @borkdude
- creates three shims
  - deps.exe
  - clj.exe
  - clojure.exe
