### PR TITLE
bbin: Create directory on install

### DIFF
--- a/bucket/bbin.json
+++ b/bucket/bbin.json
@@ -23,7 +23,10 @@
     },
     "pre_install": [
         "Remove-Item \"$dir\\*\" -Recurse -Exclude 'bbin'",
-        "Set-Content \"$dir\\bbin.bat\" \"@bb.exe \"\"%~dp0bbin\"\" %*\""
+        "Set-Content \"$dir\\bbin.bat\" \"@bb.exe \"\"%~dp0bbin\"\" %*\"",
+        "If(!(Test-Path \"$env:USERPROFILE\\.babashka\\bbin\\bin\")) {",
+        "  New-Item -ItemType \"directory\" \"$env:USERPROFILE\\.babashka\\bbin\\bin\"",
+        "}"
     ],
     "bin": "bbin.bat",
     "checkver": {


### PR DESCRIPTION
Check existence of `bbin/bin` directory and eventually create it.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
