### PR TITLE
fix: Simplify pre_install script to prevent error #197

### DIFF
--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -25,8 +25,8 @@
         }
     },
     "pre_install": [
-        "Move-Item \"$dir\\ClojureTools\\*\" \"$dir\\\" -Exclude 'ClojureTools.p*'",
-        "Remove-Item \"$dir\\ClojureTools\" -Force -Recurse"
+        "Move-Item \"$dir\\ClojureTools\\*\" \"$dir\\\"",
+        "Remove-Item \"$dir\\ClojureTools\" \"$dir\\ClojureTools.psd1\" \"$dir\\ClojureTools.psm1\" -Force -Recurse"
     ],
     "env_set": {
         "DEPS_CLJ_TOOLS_DIR": "$dir"


### PR DESCRIPTION
An attempt to avoid a bizzare behavior of Move-Item cmdlet

Closes #197

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
