### PR TITLE
README: Add instructions to add extras bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ scoop install git
 # add scoop bucket for Java
 scoop bucket add java
 
+# add scoop bucket with extras, here there is a dependency on visual studio redistributable 'extras/vcredist2015'
+scoop bucket add extras
+
 # add scoop bucket for clojure build
 scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure
 ```


### PR DESCRIPTION
New executables are linked against vcredist2015 which are available via `extras` scoop.
Added instructions how to add extras before installing `clj-deps`

Closes #199 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
