### PR TITLE
Update descriptions of deprecated manifests

### DIFF
--- a/bucket/clj-msi.json
+++ b/bucket/clj-msi.json
@@ -1,6 +1,6 @@
 {
     "version": "1.11.1.1208",
-    "description": "Clojure installation from a MSI package",
+    "description": "Use `clj-deps`. Clojure installation from a MSI package",
     "homepage": "https://clojure.org",
     "license": "EPL-1.0",
     "notes": "Please fully exit and restart any active terminal sessions.",

--- a/bucket/clojure.json
+++ b/bucket/clojure.json
@@ -1,6 +1,6 @@
 {
     "version": "1.11.1.1224",
-    "description": "Clojure is a modern, dynamic, and functional dialect of the Lisp programming language on the Java platform",
+    "description": "Use `clj-deps`. Clojure is a modern, dynamic, and functional dialect of the Lisp programming language on the Java platform",
     "homepage": "https://clojure.org",
     "license": "EPL-1.0",
     "notes": [


### PR DESCRIPTION
I consider `clojure` and `clj-msi` deprecated manifests. I updated description so it's more obvious to users.
Users should use `clj-deps`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
