### PR TITLE
joker: fix autoupdate url

### DIFF
--- a/bucket/joker.json
+++ b/bucket/joker.json
@@ -16,7 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/candid82/joker/releases/download/v$version/joker-$version-win-amd64.zip"
+                "url": "https://github.com/candid82/joker/releases/download/v$version/joker-win-amd64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The format of the joker download url has changed since 1.0.0 - this should make the autoupdater work again.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
