### PR TITLE
deps.clj: Update checkver regexp to accomodate versioning scheme

### DIFF
--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -46,7 +46,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/borkdude/deps.clj"
+        "url": "https://github.com/borkdude/deps.clj/releases",
+        "regex": "tag/v([\\d.]+)(-[\\d]+)?",
+        "replace": "${1}${2}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -55,7 +55,7 @@
             "64bit": {
                 "url": [
                     "https://github.com/borkdude/deps.clj/releases/download/v$version/deps.clj-$version-windows-amd64.zip",
-                    "https://download.clojure.org/install/clojure-tools-$version.zip"
+                    "https://download.clojure.org/install/clojure-tools-$matchHead.zip"
                 ]
             }
         }

--- a/bucket/deps.clj.json
+++ b/bucket/deps.clj.json
@@ -11,7 +11,11 @@
         }
     },
     "bin": "deps.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/borkdude/deps.clj/releases",
+        "regex": "tag/v([\\d.]+)(-[\\d]+)?",
+        "replace": "${1}${2}"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
It turned out that versioning of deps.clj matches upstream Clojure CLI versioning and eventually add suffixes like -4.
This however is not compatible with a default checker code in Scoop.

I decided to use similar technique that I use for clojure-lsp manifest where url, regex and replace sections of checker are used to form a version that can be used to check and also download artifacts.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
