### PR TITLE
clj-deps: Stuck on version, manual version bump

### DIFF
--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.11.1.1273",
+    "version": "1.11.1.1273-4",
     "description": "Modern, dynamic a functional dialect of the LISP programming language for JVM",
     "homepage": "https://clojure.org",
     "license": "EPL-1.0",
@@ -15,11 +15,11 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/borkdude/deps.clj/releases/download/v1.11.1.1273/deps.clj-1.11.1.1273-windows-amd64.zip",
+                "https://github.com/borkdude/deps.clj/releases/download/v1.11.1.1273-4/deps.clj-1.11.1.1273-4-windows-amd64.zip",
                 "https://download.clojure.org/install/clojure-tools-1.11.1.1273.zip"
             ],
             "hash": [
-                "8a2ea83d6a89efbcf8d2535fd9618a2078565933c120053ac75bccee4f707359",
+                "fd82925ba8a1d259acb5d73fef52540e78620eb25e020a857a2b900649e82a91",
                 "f1d7e7a9d19ddc309e7136fefee6875476bc76e7abee2bbae917b80f8defbca2"
             ]
         }


### PR DESCRIPTION
Manual bump for clj-deps needed.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
