### PR TITLE
vcredist: Fix all references to vcredist2015 and vcredist2010

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ scoop install git
 # add scoop bucket for Java
 scoop bucket add java
 
-# add scoop bucket with extras, here there is a dependency on visual studio redistributable 'extras/vcredist2015'
+# add scoop bucket with extras, here there is a dependency on visual studio redistributable 'extras/vcredist2022'
 scoop bucket add extras
 
 # add scoop bucket for clojure build

--- a/bucket/babashka.json
+++ b/bucket/babashka.json
@@ -3,7 +3,7 @@
     "description": "A Clojure babushka for the grey areas of Bash",
     "homepage": "https://github.com/borkdude/babashka",
     "license": "EPL-1.0",
-    "depends": "extras/vcredist2019",
+    "depends": "extras/vcredist2022",
     "suggest": {
         "curl": "curl"
     },

--- a/bucket/bb-web.json
+++ b/bucket/bb-web.json
@@ -3,7 +3,7 @@
     "description": "A babashka fork for small web-apps",
     "homepage": "https://github.com/kloimhardt/babashka-web",
     "license": "EPL-1.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/kloimhardt/babashka-web/releases/download/v0.2.4/babashka-web-0.2.4-windows-amd64.zip",

--- a/bucket/bibcal.json
+++ b/bucket/bibcal.json
@@ -3,7 +3,7 @@
     "description": "A cli calendar based on the Bible and the 1st Book of Enoch",
     "homepage": "https://github.com/johanthoren/bibcal",
     "license": "ISC",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/johanthoren/bibcal/releases/download/1.1.2/bibcal-windows-x86_64.exe",

--- a/bucket/bootleg.json
+++ b/bucket/bootleg.json
@@ -3,7 +3,7 @@
     "description": "Simple template processing command line tool to help build static websites",
     "homepage": "https://github.com/retrogradeorbit/bootleg",
     "license": "EPL-2.0",
-    "depends": "extras/vcredist2010",
+    "depends": "extras/vcredist",
     "architecture": {
         "64bit": {
             "url": "https://github.com/retrogradeorbit/bootleg/releases/download/v0.1.9/bootleg-0.1.9-windows-amd64.zip",

--- a/bucket/carve.json
+++ b/bucket/carve.json
@@ -3,7 +3,7 @@
     "description": "Carve will search through your code for unused vars and will remove them.",
     "homepage": "https://github.com/borkdude/carve",
     "license": "EPL-1.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/borkdude/carve/releases/download/v0.2.0/carve-0.2.0-windows-amd64.zip",

--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -11,7 +11,7 @@
             "java/oraclejdk"
         ]
     },
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": [

--- a/bucket/clj-kondo.json
+++ b/bucket/clj-kondo.json
@@ -3,7 +3,7 @@
     "description": "A linter for Clojure code that sparks joy",
     "homepage": "https://github.com/borkdude/clj-kondo",
     "license": "EPL-1.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/borkdude/clj-kondo/releases/download/v2023.05.26/clj-kondo-2023.05.26-windows-amd64.zip",

--- a/bucket/clojure-lsp.json
+++ b/bucket/clojure-lsp.json
@@ -3,7 +3,7 @@
     "description": "Language Server for Clojure",
     "homepage": "https://clojure-lsp.github.io/clojure-lsp",
     "license": "MIT",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/clojure-lsp/clojure-lsp/releases/download/2023.05.04-19.38.01/clojure-lsp-native-windows-amd64.zip",

--- a/bucket/cq.json
+++ b/bucket/cq.json
@@ -3,7 +3,7 @@
     "description": "Clojure Command-line Data Processor for JSON, YAML, EDN, XML and more",
     "homepage": "https://github.com/markus-wa/cq",
     "license": "EPL-2.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/markus-wa/cq/releases/download/2022.11.14-14.16.12/cq-native-windows.exe#/cq.exe",

--- a/bucket/deps.clj.json
+++ b/bucket/deps.clj.json
@@ -3,7 +3,7 @@
     "description": "A port of the clojure bash script to Clojure",
     "homepage": "https://github.com/borkdude/deps.clj",
     "license": "EPL-1.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/borkdude/deps.clj/releases/download/v1.11.1.1273/deps.clj-1.11.1.1273-windows-amd64.zip",

--- a/bucket/grasp.json
+++ b/bucket/grasp.json
@@ -3,7 +3,7 @@
     "description": "Grep Clojure code using clojure.spec regexes",
     "homepage": "https://github.com/borkdude/grasp",
     "license": "EPL-1.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/borkdude/grasp/releases/download/v0.1.4/grasp-0.1.4-windows-amd64.zip",

--- a/bucket/jet.json
+++ b/bucket/jet.json
@@ -3,7 +3,7 @@
     "description": "CLI to transform between JSON, EDN and Transit, powered with a minimal query language",
     "homepage": "https://github.com/borkdude/jet",
     "license": "EPL-1.0",
-    "depends": "extras/vcredist2010",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/borkdude/jet/releases/download/v0.5.25/jet-0.5.25-windows-amd64.zip",

--- a/bucket/lmgrep.json
+++ b/bucket/lmgrep.json
@@ -3,7 +3,7 @@
     "description": "Grep-like utility based on Lucene Monitor.",
     "homepage": "https://github.com/dainiusjocas/lucene-grep",
     "license": "Apache-2.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/dainiusjocas/lucene-grep/releases/download/v2023.05.13/lmgrep-v2023.05.13-windows-amd64.zip",

--- a/bucket/pgmig.json
+++ b/bucket/pgmig.json
@@ -3,7 +3,7 @@
     "description": "Standalone PostgreSQL migration runner",
     "homepage": "https://github.com/leafclick/pgmig",
     "license": "Apache-2.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/leafclick/pgmig/releases/download/v0.7.1/pgmig-0.7.1-windows-amd64.zip",

--- a/bucket/puget.json
+++ b/bucket/puget.json
@@ -3,7 +3,7 @@
     "description": "A CLI version of puget",
     "homepage": "https://github.com/borkdude/puget-cli",
     "license": "EPL-1.0",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/borkdude/puget-cli/releases/download/v0.0.3/puget-cli-0.0.3-windows-amd64.zip",

--- a/bucket/shh.json
+++ b/bucket/shh.json
@@ -3,7 +3,7 @@
     "description": "A CLI password manager designed for efficiency",
     "homepage": "https://github.com/askonomm/shh",
     "license": "MIT",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
             "url": "https://github.com/askonomm/shh/releases/download/2021.10.20/shh.exe",


### PR DESCRIPTION
Microsoft did some changes in the way Visual Studio redistributable runtimes are available.
This was reflected in some important scoop formulas that we use as dependencies here in the bucket.

The changes are following: 
1. All the vcredist libraries including version 2013 and lower are newly available via `extras/vcredist` 
2. All the vcredist libraries including version 2015 and higher are newly available via `extras/vcredist2022`

It means that all scoop manifest needs to be updated to reference to the second case except the single case (bootlet) where we stil have a dependency on the former.

These installation steps need to be taken to recover form the change:

```
scoop uninstall vcredist2005 vcredist2008 vcredist2010 vcredist2012 vcredist2013 vcredist
scoop update
scoop install vcredist vcredist2022
```

I'm unsure if the second step is needed, but it doesn't hurt and may overcome an intermediate vacuum of inconsistency during the upgrade.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
