### PR TITLE
clj-deps: Update to version 1.11.1.1403

### DIFF
--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -55,7 +55,7 @@
             "64bit": {
                 "url": [
                     "https://github.com/borkdude/deps.clj/releases/download/v$version/deps.clj-$version-windows-amd64.zip",
-                    "https://github.com/clojure/brew-install/releases/download/$matchHead/clojure-tools.zip"
+                    "https://github.com/clojure/brew-install/releases/download/${1}/clojure-tools.zip"
                 ]
             }
         }

--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -55,7 +55,7 @@
             "64bit": {
                 "url": [
                     "https://github.com/borkdude/deps.clj/releases/download/v$version/deps.clj-$version-windows-amd64.zip",
-                    "https://github.com/clojure/brew-install/releases/download/${1}/clojure-tools.zip"
+                    "https://github.com/clojure/brew-install/releases/download/$matchHead$matchTail/clojure-tools.zip"
                 ]
             }
         }

--- a/bucket/clj-deps.json
+++ b/bucket/clj-deps.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.11.1.1273-4",
+    "version": "1.11.1.1403",
     "description": "Modern, dynamic a functional dialect of the LISP programming language for JVM",
     "homepage": "https://clojure.org",
     "license": "EPL-1.0",
@@ -15,12 +15,12 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/borkdude/deps.clj/releases/download/v1.11.1.1273-4/deps.clj-1.11.1.1273-4-windows-amd64.zip",
-                "https://download.clojure.org/install/clojure-tools-1.11.1.1273.zip"
+                "https://github.com/borkdude/deps.clj/releases/download/v1.11.1.1403/deps.clj-1.11.1.1403-windows-amd64.zip",
+                "https://github.com/clojure/brew-install/releases/download/1.11.1.1403/clojure-tools.zip"
             ],
             "hash": [
-                "fd82925ba8a1d259acb5d73fef52540e78620eb25e020a857a2b900649e82a91",
-                "f1d7e7a9d19ddc309e7136fefee6875476bc76e7abee2bbae917b80f8defbca2"
+                "278f3020884155b92e255ee41cb2930445719d1ef1fa0457e7868d26610d4735",
+                "e40a5a330b7ed7ab9874ed4f6cd3062a97e20b7973e24f9c4772b2945b1ca68d"
             ]
         }
     },
@@ -55,7 +55,7 @@
             "64bit": {
                 "url": [
                     "https://github.com/borkdude/deps.clj/releases/download/v$version/deps.clj-$version-windows-amd64.zip",
-                    "https://download.clojure.org/install/clojure-tools-$matchHead.zip"
+                    "https://github.com/clojure/brew-install/releases/download/$matchHead/clojure-tools.zip"
                 ]
             }
         }


### PR DESCRIPTION
Change the location of the downloaded artifacts to release tags of [brew-install](https://github.com/clojure/brew-install) repository.

Closes #207 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
