### PR TITLE
clojure: Update release location

### DIFF
--- a/bucket/clojure.json
+++ b/bucket/clojure.json
@@ -18,7 +18,7 @@
             "java/oraclejdk"
         ]
     },
-    "url": "https://download.clojure.org/install/clojure-tools-1.11.1.1386.zip",
+    "url": "https://github.com/clojure/brew-install/releases/download/1.11.1.1386/clojure-tools.zip",
     "hash": "1b07b09adf3c763650574ca2005011e0d89a195c551e21da30a3f94e9a2cfd47",
     "extract_dir": "ClojureTools",
     "psmodule": {
@@ -37,10 +37,9 @@
         ]
     ],
     "checkver": {
-        "url": "https://clojure.org/releases/tools",
-        "regex": "(\\d+\\.\\d+\\.\\d+\\.\\d+) \\("
+        "github": "https://github.com/clojure/brew-install"
     },
     "autoupdate": {
-        "url": "https://download.clojure.org/install/clojure-tools-$version.zip"
+        "url": "https://github.com/clojure/brew-install/releases/download/$version/clojure-tools.zip"
     }
 }


### PR DESCRIPTION
This only updates release download location to Github releases

Relates to #207

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
