### PR TITLE
change path to follow XDG standard

### DIFF
--- a/bucket/bbin.json
+++ b/bucket/bbin.json
@@ -4,8 +4,7 @@
     "homepage": "https://github.com/babashka/bbin",
     "license": "MIT",
     "notes": [
-        "Folder ~\\.babashka\\bbin\\bin was added to your PATH environment variable.",
-        "Please fully exit and restart any active terminal sessions."
+        "Folder ~\\.local\\bin was added to your PATH environment variable."
     ],
     "depends": "scoop-clojure/babashka",
     "architecture": {
@@ -16,16 +15,16 @@
         }
     },
     "installer": {
-        "script": "add_first_in_path \"$env:USERPROFILE\\.babashka\\bbin\\bin\" $global"
+        "script": "add_first_in_path \"$env:USERPROFILE\\.local\\bin\" $global"
     },
     "uninstaller": {
-        "script": "remove_from_path \"$env:USERPROFILE\\.babashka\\bbin\\bin\" $global"
+        "script": "remove_from_path \"$env:USERPROFILE\\.local\\bin\" $global"
     },
     "pre_install": [
         "Remove-Item \"$dir\\*\" -Recurse -Exclude 'bbin'",
         "Set-Content \"$dir\\bbin.bat\" \"@bb.exe \"\"%~dp0bbin\"\" %*\"",
-        "If(!(Test-Path \"$env:USERPROFILE\\.babashka\\bbin\\bin\")) {",
-        "  New-Item -ItemType \"directory\" \"$env:USERPROFILE\\.babashka\\bbin\\bin\"",
+        "If(!(Test-Path \"$env:USERPROFILE\\.local\\bin\")) {",
+        "  New-Item -ItemType \"directory\" \"$env:USERPROFILE\\.local\\bin\"",
         "}"
     ],
     "bin": "bbin.bat",


### PR DESCRIPTION
bbin deside to follow XDG directory structure. This requires a slight change in the script.

One big downside is now that uninstaller section removes the path for anyone else. Let's see if that causes any trouble.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
