### PR TITLE
hiccup-cli: Add version 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Emacs users should now issue `clj` and `clojure` commands without hassle.
 - [cq](https://github.com/markus-wa/cq): Clojure Command-line Data Processor for JSON, YAML, EDN, XML and more
 - [datalevin](https://github.com/juji-io/datalevin): A simple, fast and durable Datalog database
 - [grasp](https://github.com/borkdude/grasp): Grep Clojure code using clojure.spec regexes
+- [hiccup-cli](https://github.com/kwrooijen/hiccup-cli): CLI to convert HTML to Hiccup syntax
 - [jet](https://github.com/borkdude/jet): CLI to transform between JSON, EDN and Transit, powered with a minimal query language
 - [joker](https://joker-lang.org): A small interpreted dialect of Clojure written in Go. It is also a Clojure(Script) linter
 - [lmgrep](https://github.com/dainiusjocas/lucene-grep): A Grep-like utility based on Lucene Monitor
@@ -110,6 +111,7 @@ scoop install clj-kondo
 scoop install clojure-lsp
 scoop install cq
 scoop install datalevin
+scoop install hiccup-cli
 scoop install grasp
 scoop install jet
 scoop install joker

--- a/bucket/hiccup-cli.json
+++ b/bucket/hiccup-cli.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.1.0",
+    "description": "CLI to convert HTML to Hiccup syntax",
+    "homepage": "https://github.com/kwrooijen/hiccup-cli",
+    "license": "MIT",
+    "depends": "extras/vcredist2022",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/kwrooijen/hiccup-cli/releases/download/0.1.0/hiccup-cli-windows-amd64.zip",
+            "hash": "fb0e63f023779ef87c8534f49f8c3380b12fcf1e6d945773f74bc4945406e43d"
+        }
+    },
+    "bin": "hiccup-cli.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kwrooijen/hiccup-cli/releases/download/$version/hiccup-cli-windows-amd64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
A bit crude but still useful CLI to convert HTML to Hiccup syntax.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
