### PR TITLE
[FIX] (clj-kondo): releases now hosted under organization clj-kondo

### DIFF
--- a/bucket/clj-kondo.json
+++ b/bucket/clj-kondo.json
@@ -1,12 +1,12 @@
 {
     "version": "2024.11.14",
     "description": "A linter for Clojure code that sparks joy",
-    "homepage": "https://github.com/borkdude/clj-kondo",
+    "homepage": "https://github.com/clj-kondo/clj-kondo",
     "license": "EPL-1.0",
     "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/borkdude/clj-kondo/releases/download/v2024.11.14/clj-kondo-2024.11.14-windows-amd64.zip",
+            "url": "https://github.com/clj-kondo/clj-kondo/releases/download/v2024.11.14/clj-kondo-2024.11.14-windows-amd64.zip",
             "hash": "1d359388e006a3def27984fdbb5455d06a965447c1c0a1c0a5431dc53fa36b28"
         }
     },
@@ -15,7 +15,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/borkdude/clj-kondo/releases/download/v$version/clj-kondo-$version-windows-amd64.zip"
+                "url": "https://github.com/clj-kondo/clj-kondo/releases/download/v$version/clj-kondo-$version-windows-amd64.zip"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
